### PR TITLE
Only use Bark wood variant for trees

### DIFF
--- a/src/main/java/org/betterx/betternether/world/features/AnchorTreeBranchFeature.java
+++ b/src/main/java/org/betterx/betternether/world/features/AnchorTreeBranchFeature.java
@@ -160,10 +160,8 @@ public class AnchorTreeBranchFeature extends ContextFeature<NoneFeatureConfigura
 
 
         for (BlockPos bpos : context.POINTS) {
-            if (context.POINTS.contains(bpos.above()) && context.POINTS.contains(bpos.below()))
-                state = NetherBlocks.MAT_ANCHOR_TREE.getLog().defaultBlockState();
-            else
-                state = NetherBlocks.MAT_ANCHOR_TREE.getBark().defaultBlockState();
+
+            state = NetherBlocks.MAT_ANCHOR_TREE.getBark().defaultBlockState();
 
             BlocksHelper.setWithUpdate(world, bpos, state);
 

--- a/src/main/java/org/betterx/betternether/world/features/AnchorTreeFeature.java
+++ b/src/main/java/org/betterx/betternether/world/features/AnchorTreeFeature.java
@@ -152,11 +152,10 @@ public class AnchorTreeFeature extends ContextFeature<NoneFeatureConfiguration> 
             if (!blockBox.isInside(bpos)) continue;
             if (!BlocksHelper.isNetherGround(state = level.getBlockState(bpos)) && !state.canBeReplaced())
                 continue;
-            boolean blockUp = true;
-            if ((blockUp = context.BLOCKS.contains(bpos.above())) && context.BLOCKS.contains(bpos.below()))
-                BlocksHelper.setWithoutUpdate(level, bpos, NetherBlocks.MAT_ANCHOR_TREE.getLog().defaultBlockState());
-            else
-                BlocksHelper.setWithoutUpdate(level, bpos, NetherBlocks.MAT_ANCHOR_TREE.getBark().defaultBlockState());
+
+            boolean blockUp = context.BLOCKS.contains(bpos.above());
+
+            BlocksHelper.setWithoutUpdate(level, bpos, NetherBlocks.MAT_ANCHOR_TREE.getBark().defaultBlockState());
 
             if (bpos.getY() > HEIGHT_45 && bpos.getY() < HEIGHT_90 && (bpos.getY() & 3) == offset && NOISE.eval(
                     bpos.getX() * 0.1,

--- a/src/main/java/org/betterx/betternether/world/features/AnchorTreeRootFeature.java
+++ b/src/main/java/org/betterx/betternether/world/features/AnchorTreeRootFeature.java
@@ -65,12 +65,11 @@ public class AnchorTreeRootFeature extends ContextFeature<NoneFeatureConfigurati
             //if (!blockBox.contains(bpos)) continue;
             if (bpos.getY() < minBuildHeight || bpos.getY() > MAX_HEIGHT - 2) continue;
             if (!BlocksHelper.isNetherGround(state = world.getBlockState(bpos)) && !canReplace(state)) continue;
-            boolean blockUp;
-            boolean blockDown = true;
-            if ((blockUp = context.BLOCKS.contains(bpos.above())) && (blockDown = context.BLOCKS.contains(bpos.below())))
-                BlocksHelper.setWithoutUpdate(world, bpos, NetherBlocks.MAT_ANCHOR_TREE.getLog().defaultBlockState());
-            else
-                BlocksHelper.setWithoutUpdate(world, bpos, NetherBlocks.MAT_ANCHOR_TREE.getBark().defaultBlockState());
+
+            boolean blockUp = context.BLOCKS.contains(bpos.above());
+            boolean blockDown = context.BLOCKS.contains(bpos.below());
+
+            BlocksHelper.setWithoutUpdate(world, bpos, NetherBlocks.MAT_ANCHOR_TREE.getBark().defaultBlockState());
 
             if (!blockUp && world.getBlockState(bpos.above()).canBeReplaced()) {
                 BlocksHelper.setWithoutUpdate(world, bpos.above(), NetherBlocks.MOSS_COVER.defaultBlockState());

--- a/src/main/java/org/betterx/betternether/world/features/NetherSakuraFeature.java
+++ b/src/main/java/org/betterx/betternether/world/features/NetherSakuraFeature.java
@@ -75,7 +75,7 @@ public class NetherSakuraFeature extends ContextFeature<NoneFeatureConfiguration
                                 BlocksHelper.setWithUpdate(
                                         world,
                                         context.POS,
-                                        NetherBlocks.MAT_NETHER_SAKURA.getLog().defaultBlockState()
+                                        NetherBlocks.MAT_NETHER_SAKURA.getBark().defaultBlockState()
                                 );
                                 updateSDFFrom(context.POS, context);
                             }

--- a/src/main/java/org/betterx/betternether/world/features/OldWillowTree.java
+++ b/src/main/java/org/betterx/betternether/world/features/OldWillowTree.java
@@ -121,20 +121,12 @@ public class OldWillowTree extends NonOverlappingFeature<NaturalTreeConfiguratio
         for (BlockPos bpos : context.BLOCKS) {
             if (!blockBox.isInside(bpos)) continue;
             if (BlocksHelper.isNetherGround(state = world.getBlockState(bpos)) || state.canBeReplaced()) {
-                if (!context.BLOCKS.contains(bpos.above()) || !context.BLOCKS.contains(bpos.below()))
-                    BlocksHelper.setWithUpdate(
-                            world,
-                            bpos,
-                            NetherBlocks.MAT_WILLOW.getBlock(WoodSlots.BARK)
-                                                   .defaultBlockState()
-                    );
-                else
-                    BlocksHelper.setWithUpdate(
-                            world,
-                            bpos,
-                            NetherBlocks.MAT_WILLOW.getBlock(WoodSlots.LOG)
-                                                   .defaultBlockState()
-                    );
+                BlocksHelper.setWithUpdate(
+                        world,
+                        bpos,
+                        NetherBlocks.MAT_WILLOW.getBlock(WoodSlots.BARK)
+                                .defaultBlockState()
+                );
 
                 if (random.nextInt(8) == 0) {
                     Block[] wallPlants = WALL_PLANTS.get();
@@ -191,7 +183,8 @@ public class OldWillowTree extends NonOverlappingFeature<NaturalTreeConfiguratio
 
     @Override
     protected boolean isStructure(BlockState state) {
-        return state.getBlock() == NetherBlocks.MAT_RUBEUS.getLog();
+        return state.getBlock() == NetherBlocks.MAT_RUBEUS.getBark()
+                || state.getBlock() == NetherBlocks.MAT_RUBEUS.getLog();
     }
 
     @Override

--- a/src/main/java/org/betterx/betternether/world/features/RubeusTreeFeature.java
+++ b/src/main/java/org/betterx/betternether/world/features/RubeusTreeFeature.java
@@ -31,7 +31,8 @@ public class RubeusTreeFeature extends NonOverlappingFeature<NaturalTreeConfigur
 
     @Override
     protected boolean isStructure(BlockState state) {
-        return state.getBlock() == NetherBlocks.MAT_RUBEUS.getLog();
+        return state.getBlock() == NetherBlocks.MAT_RUBEUS.getBark()
+                || state.getBlock() == NetherBlocks.MAT_RUBEUS.getLog();
     }
 
     @Override
@@ -205,7 +206,7 @@ public class RubeusTreeFeature extends NonOverlappingFeature<NaturalTreeConfigur
 
         for (BlockPos bpos : context.POINTS) {
             if (context.POINTS.contains(bpos.above()) && context.POINTS.contains(bpos.below())) {
-                state = NetherBlocks.MAT_RUBEUS.getLog().defaultBlockState();
+                state = NetherBlocks.MAT_RUBEUS.getBark().defaultBlockState();
                 if (context.MIDDLE.contains(bpos))
                     setCondition(
                             world,

--- a/src/main/java/org/betterx/betternether/world/features/WartTreeFeature.java
+++ b/src/main/java/org/betterx/betternether/world/features/WartTreeFeature.java
@@ -175,7 +175,9 @@ public class WartTreeFeature extends NonOverlappingFeature<NaturalTreeConfigurat
     }
 
     private boolean isWart(BlockState state) {
-        return state == WART_BLOCK || state.getBlock() == NetherBlocks.MAT_WART.getLog();
+        return state == WART_BLOCK
+                || state.getBlock() == NetherBlocks.MAT_WART.getLog()
+                || state.getBlock() == NetherBlocks.MAT_WART.getBark();
     }
 
     @Override


### PR DESCRIPTION
Fixes issues with veinmine/ultimine where the feature will not detect the tree properly due to some blocks being barks and others being logs. There were no visual impacts to the trees as a result.