### PR TITLE
Improved music system

### DIFF
--- a/src/main/java/org/betterx/betternether/mixin/client/MusicTrackerMixin.java
+++ b/src/main/java/org/betterx/betternether/mixin/client/MusicTrackerMixin.java
@@ -67,7 +67,7 @@ public class MusicTrackerMixin {
                 // Fade out current music
                 volumeChanged = true;
                 bn_volume -= FADE_SPEED * TICK_DELTA;
-                nextSongDelay = random.nextInt(0, targetMusic.getMinDelay() / 2);
+                nextSongDelay = random.nextInt(0, Math.max(targetMusic.getMinDelay() / 2, 1));
                 if (bn_volume <= 0.0f) {
                     bn_thisObj.stopPlaying();
                 }


### PR DESCRIPTION
This PR brings the music tracker rewrite from https://github.com/Reijin2312/BetterEnd_Neoforge/pull/30 to BetterNether. Currently, the old system will sometimes cut the music instead of fading out. I suspect it is due to BetterEnd and BetterNether sharing the same static variable names.

The new system has been optimized to take quick exits and not do any unnecessary checks. This should also be a lot more readable and maintainable than the previous one with the added comments and better clarity.