### PR TITLE
Improve C2ME worldgen thread safety

### DIFF
--- a/src/main/java/org/betterx/betternether/world/biomes/providers/NetherGrasslandsNumericProvider.java
+++ b/src/main/java/org/betterx/betternether/world/biomes/providers/NetherGrasslandsNumericProvider.java
@@ -1,7 +1,6 @@
 package org.betterx.betternether.world.biomes.providers;
 
 
-import org.betterx.betternether.MHelper;
 import org.betterx.wover.surface.api.conditions.SurfaceRulesContext;
 import org.betterx.wover.surface.api.noise.NumericProvider;
 
@@ -20,9 +19,22 @@ public class NetherGrasslandsNumericProvider implements NumericProvider {
     @Override
     public int getNumber(SurfaceRulesContext ctx) {
         final int depth = ctx.getStoneDepthAbove();
-        if (depth <= 1) return MHelper.RANDOM.nextInt(3);
-        if (depth <= MHelper.RANDOM.nextInt(3) + 1) return 0;
+        if (depth <= 1) return randomInt(ctx, 0, 3);
+        if (depth <= randomInt(ctx, 1, 3) + 1) return 0;
         return 2;
+    }
+
+    private static int randomInt(SurfaceRulesContext ctx, int salt, int bound) {
+        int hash = ctx.getBlockX();
+        hash = 31 * hash + ctx.getBlockY();
+        hash = 31 * hash + ctx.getBlockZ();
+        hash = 31 * hash + salt;
+        hash ^= hash >>> 16;
+        hash *= 0x7feb352d;
+        hash ^= hash >>> 15;
+        hash *= 0x846ca68b;
+        hash ^= hash >>> 16;
+        return Math.floorMod(hash, bound);
     }
 
     @Override

--- a/src/main/java/org/betterx/betternether/world/biomes/providers/NetherMushroomForestEdgeNumericProvider.java
+++ b/src/main/java/org/betterx/betternether/world/biomes/providers/NetherMushroomForestEdgeNumericProvider.java
@@ -1,7 +1,6 @@
 package org.betterx.betternether.world.biomes.providers;
 
 
-import org.betterx.betternether.MHelper;
 import org.betterx.wover.surface.api.conditions.SurfaceRulesContext;
 import org.betterx.wover.surface.api.noise.NumericProvider;
 
@@ -15,7 +14,20 @@ public class NetherMushroomForestEdgeNumericProvider implements NumericProvider 
 
     @Override
     public int getNumber(SurfaceRulesContext ctx) {
-        return MHelper.RANDOM.nextInt(4) > 0 ? 0 : (MHelper.RANDOM.nextBoolean() ? 1 : 2);
+        return randomInt(ctx, 0, 4) > 0 ? 0 : (randomInt(ctx, 1, 2) == 0 ? 1 : 2);
+    }
+
+    private static int randomInt(SurfaceRulesContext ctx, int salt, int bound) {
+        int hash = ctx.getBlockX();
+        hash = 31 * hash + ctx.getBlockY();
+        hash = 31 * hash + ctx.getBlockZ();
+        hash = 31 * hash + salt;
+        hash ^= hash >>> 16;
+        hash *= 0x7feb352d;
+        hash ^= hash >>> 15;
+        hash *= 0x846ca68b;
+        hash ^= hash >>> 16;
+        return Math.floorMod(hash, bound);
     }
 
     @Override

--- a/src/main/java/org/betterx/betternether/world/features/BlockFixFeature.java
+++ b/src/main/java/org/betterx/betternether/world/features/BlockFixFeature.java
@@ -28,6 +28,24 @@ public class BlockFixFeature extends DefaultFeature {
 
     private static void fixBlocks(WorldGenLevel world, int x1, int y1, int z1, int x2, int y2, int z2) {
         final StructureGeneratorThreadContext ctx = NetherThreadDataStorage.generatorForThread().context;
+        ctx.clear();
+        try {
+            fixBlocks(world, x1, y1, z1, x2, y2, z2, ctx);
+        } finally {
+            ctx.clear();
+        }
+    }
+
+    private static void fixBlocks(
+            WorldGenLevel world,
+            int x1,
+            int y1,
+            int z1,
+            int x2,
+            int y2,
+            int z2,
+            StructureGeneratorThreadContext ctx
+    ) {
         final MutableBlockPos popPos = ctx.POS;
         final MutableBlockPos abovePos = ctx.POS2;
         final MutableBlockPos belowPos = ctx.POS3;

--- a/src/main/java/org/betterx/betternether/world/features/CavesFeature.java
+++ b/src/main/java/org/betterx/betternether/world/features/CavesFeature.java
@@ -2,6 +2,7 @@ package org.betterx.betternether.world.features;
 
 import org.betterx.bclib.api.v2.levelgen.features.features.DefaultFeature;
 import org.betterx.betternether.world.structures.StructureCaves;
+import org.betterx.betternether.world.structures.StructureGeneratorThreadContext;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.RandomSource;
@@ -17,15 +18,21 @@ public class CavesFeature extends DefaultFeature {
         final WorldGenLevel level = featurePlaceContext.level();
         final int sx = (worldPos.getX() >> 4) << 4;
         final int sz = (worldPos.getZ() >> 4) << 4;
+        final StructureGeneratorThreadContext context = NetherThreadDataStorage.generatorForThread().context;
 
-        caves.generate(
-                level,
-                new BlockPos(sx, 0, sz),
-                random,
-                featurePlaceContext.chunkGenerator().getGenDepth(),
-                NetherThreadDataStorage.generatorForThread().context
-        );
-        return true;
+        context.clear();
+        try {
+            caves.generate(
+                    level,
+                    new BlockPos(sx, 0, sz),
+                    random,
+                    featurePlaceContext.chunkGenerator().getGenDepth(),
+                    context
+            );
+            return true;
+        } finally {
+            context.clear();
+        }
     }
 
     private static StructureCaves caves;

--- a/src/main/java/org/betterx/betternether/world/features/ContextFeature.java
+++ b/src/main/java/org/betterx/betternether/world/features/ContextFeature.java
@@ -17,14 +17,20 @@ public abstract class ContextFeature<FC extends FeatureConfiguration> extends Fe
 
     @Override
     public final boolean place(FeaturePlaceContext<FC> ctx) {
-        return place(
-                ctx.level(),
-                ctx.origin(),
-                ctx.random(),
-                ctx.config(),
-                ctx.chunkGenerator().getGenDepth(),
-                NetherThreadDataStorage.generatorForThread().context
-        );
+        StructureGeneratorThreadContext context = NetherThreadDataStorage.generatorForThread().context;
+        context.clear();
+        try {
+            return place(
+                    ctx.level(),
+                    ctx.origin(),
+                    ctx.random(),
+                    ctx.config(),
+                    ctx.chunkGenerator().getGenDepth(),
+                    context
+            );
+        } finally {
+            context.clear();
+        }
     }
 
     protected abstract boolean place(

--- a/src/main/java/org/betterx/betternether/world/features/NetherSurfaceFeature.java
+++ b/src/main/java/org/betterx/betternether/world/features/NetherSurfaceFeature.java
@@ -23,13 +23,19 @@ public abstract class NetherSurfaceFeature extends Feature<NoneFeatureConfigurat
     }
 
     protected void generate(BlockPos centerPos, FeaturePlaceContext<NoneFeatureConfiguration> ctx) {
-        generate(
-                ctx.level(),
-                centerPos,
-                ctx.random(),
-                ctx.chunkGenerator().getGenDepth(),
-                NetherThreadDataStorage.generatorForThread().context
-        );
+        StructureGeneratorThreadContext context = NetherThreadDataStorage.generatorForThread().context;
+        context.clear();
+        try {
+            generate(
+                    ctx.level(),
+                    centerPos,
+                    ctx.random(),
+                    ctx.chunkGenerator().getGenDepth(),
+                    context
+            );
+        } finally {
+            context.clear();
+        }
     }
 
     protected abstract void generate(

--- a/src/main/java/org/betterx/betternether/world/features/PathsFeature.java
+++ b/src/main/java/org/betterx/betternether/world/features/PathsFeature.java
@@ -2,6 +2,7 @@ package org.betterx.betternether.world.features;
 
 import org.betterx.bclib.api.v2.levelgen.features.features.DefaultFeature;
 import org.betterx.betternether.world.structures.StructurePath;
+import org.betterx.betternether.world.structures.StructureGeneratorThreadContext;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.RandomSource;
@@ -17,15 +18,21 @@ public class PathsFeature extends DefaultFeature {
         final WorldGenLevel level = featurePlaceContext.level();
         final int sx = (worldPos.getX() >> 4) << 4;
         final int sz = (worldPos.getZ() >> 4) << 4;
+        final StructureGeneratorThreadContext context = NetherThreadDataStorage.generatorForThread().context;
 
-        paths.generate(
-                level,
-                new BlockPos(sx, 0, sz),
-                random,
-                featurePlaceContext.chunkGenerator().getGenDepth(),
-                NetherThreadDataStorage.generatorForThread().context
-        );
-        return true;
+        context.clear();
+        try {
+            paths.generate(
+                    level,
+                    new BlockPos(sx, 0, sz),
+                    random,
+                    featurePlaceContext.chunkGenerator().getGenDepth(),
+                    context
+            );
+            return true;
+        } finally {
+            context.clear();
+        }
     }
 
     private static StructurePath paths;

--- a/src/main/java/org/betterx/betternether/world/structures/StructureCaves.java
+++ b/src/main/java/org/betterx/betternether/world/structures/StructureCaves.java
@@ -11,7 +11,6 @@ import net.minecraft.world.level.levelgen.LegacyRandomSource;
 
 public class StructureCaves implements IStructure {
 
-    private int offset = 12;
     private final OpenSimplexNoise heightNoise;
     private final OpenSimplexNoise rigidNoise;
     private final OpenSimplexNoise distortX;
@@ -34,7 +33,7 @@ public class StructureCaves implements IStructure {
             StructureGeneratorThreadContext context
     ) {
         boolean isVoid = true;
-        offset = (int) (getHeight(pos.getX() + 8, pos.getZ() + 8) - 12);
+        context.CAVE_OFFSET = (int) (getHeight(pos.getX() + 8, pos.getZ() + 8) - 12);
 
         for (int x = 0; x < 16; x++) {
             int wx = pos.getX() + x;
@@ -45,7 +44,7 @@ public class StructureCaves implements IStructure {
                 double rigid = getRigid(wx, wz);
 
                 for (int y = 0; y < 24; y++) {
-                    int wy = offset + y;
+                    int wy = context.CAVE_OFFSET + y;
 
                     double hRigid = Math.abs(wy - height);
                     double sdf = -opSmoothUnion(-hRigid / 30, -rigid, 0.15);
@@ -67,7 +66,7 @@ public class StructureCaves implements IStructure {
             for (int z = 0; z < 16; z++) {
                 int wz = pos.getZ() + z;
                 for (int y = 23; y >= 0; y--) {
-                    int wy = offset + y;
+                    int wy = context.CAVE_OFFSET + y;
                     context.POS.set(wx, wy, wz);
                     if (context.MASK[x][y][z] && BlocksHelper.isTerrain(world.getBlockState(
                             context.POS))) {
@@ -108,8 +107,8 @@ public class StructureCaves implements IStructure {
     }
 
     public boolean isInCave(int x, int y, int z, StructureGeneratorThreadContext context) {
-        int y2 = y - offset;
-        if (y2 >= 0 && y < 24)
+        int y2 = y - context.CAVE_OFFSET;
+        if (y2 >= 0 && y2 < 24)
             return context.MASK[x][y2][z];
         else
             return false;

--- a/src/main/java/org/betterx/betternether/world/structures/StructureGeneratorThreadContext.java
+++ b/src/main/java/org/betterx/betternether/world/structures/StructureGeneratorThreadContext.java
@@ -2,6 +2,7 @@ package org.betterx.betternether.world.structures;
 
 import net.minecraft.core.BlockPos;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -17,6 +18,7 @@ public class StructureGeneratorThreadContext {
     public final Map<BlockPos, Byte> LOGS_DIST = new HashMap<>(1024);
     public final Set<BlockPos> BLOCKS = new HashSet<BlockPos>(2048);
     public final boolean[][][] MASK = new boolean[16][24][16];
+    public int CAVE_OFFSET;
 
     public void clear() {
         POINTS.clear();
@@ -24,5 +26,11 @@ public class StructureGeneratorThreadContext {
         TOP.clear();
         BLOCKS.clear();
         LOGS_DIST.clear();
+        CAVE_OFFSET = 0;
+        for (boolean[][] slice : MASK) {
+            for (boolean[] column : slice) {
+                Arrays.fill(column, false);
+            }
+        }
     }
 }

--- a/src/main/java/org/betterx/betternether/world/structures/city/palette/CityPalette.java
+++ b/src/main/java/org/betterx/betternether/world/structures/city/palette/CityPalette.java
@@ -516,11 +516,11 @@ public class CityPalette {
 
     public BlockState getPlant(BlockState input) {
         String seed = BuiltInRegistries.BLOCK.getKey(input.getBlock()).getPath();
-        RANDOM.setSeed(seed.hashCode());
+        LegacyRandomSource random = new LegacyRandomSource(seed.hashCode());
         return NetherBlocks.POTTED_PLANT.defaultBlockState()
                                         .setValue(
                                                 BlockPottedPlant.PLANT,
-                                                BNBlockProperties.PottedPlantShape.values()[RANDOM.nextInt(
+                                                BNBlockProperties.PottedPlantShape.values()[random.nextInt(
                                                         BNBlockProperties.PottedPlantShape.values().length)]
                                         );
     }

--- a/src/main/java/org/betterx/betternether/world/structures/city/palette/CityPalette.java
+++ b/src/main/java/org/betterx/betternether/world/structures/city/palette/CityPalette.java
@@ -7,7 +7,6 @@ import org.betterx.betternether.registry.NetherBlocks;
 
 import net.minecraft.core.Direction;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.LegacyRandomSource;
@@ -16,7 +15,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class CityPalette {
-    private static final RandomSource RANDOM = new LegacyRandomSource(130520220057l);
     private final String name;
 
     private final List<Block> foundationBlocks = new ArrayList<Block>();
@@ -194,8 +192,7 @@ public class CityPalette {
             return list.get(0);
 
         String seed = BuiltInRegistries.BLOCK.getKey(state.getBlock()).getPath();
-        RANDOM.setSeed(seed.hashCode());
-        return list.get(RANDOM.nextInt(list.size()));
+        return list.get(new LegacyRandomSource(seed.hashCode()).nextInt(list.size()));
     }
 
     private BlockState getFullState(BlockState input, List<Block> list) {


### PR DESCRIPTION
## Summary
- clear per-thread BetterNether worldgen context before and after feature placement paths that reuse ThreadLocal state
- reset the context cave mask and move cave offset into the per-thread context instead of shared StructureCaves state
- replace shared mutable palette random and surface-rule thread-local randomness with deterministic per-call choices

## Notes
- This is scoped to C2ME threaded worldgen safety without disabling C2ME globally.
- Local Gradle validation is still pending: the workspace Gradle run stalled in filesystem/input hashing before reaching a useful Java diagnostic. The source delta has been reviewed and the branch is intentionally draft until validation is completed.